### PR TITLE
fix(prh_web_technology): Amazon Web Service

### DIFF
--- a/dict/prh_web_technology.yml
+++ b/dict/prh_web_technology.yml
@@ -55,7 +55,7 @@ rules:
     prh: （技術用語）
   - expected: Amazon Web Services
     patterns:
-      - Amazon Web Service
+      - /Amazon Web Service([^s]|$)/
     prh: （技術用語）
   - expected: Bootstrap 4
     patterns:


### PR DESCRIPTION
Amazon Web Servicesが無条件に誤字認定されていたため修正（by VSC拡張機能）

![image](https://user-images.githubusercontent.com/5842851/57008914-5f9e0e00-6c2e-11e9-9488-1e1c5ec7cd56.png)

いつも便利に使わせていただいております。 😺 