### PR TITLE
fix(prh_web_technology): Chatwork

### DIFF
--- a/dict/prh_web_technology.yml
+++ b/dict/prh_web_technology.yml
@@ -56,10 +56,10 @@ rules:
     patterns:
       - Bootstrap4
     prh: （技術用語）
-  - expected: ChatWork
+  - expected: Chatwork
     patterns:
       - Chat Work
-      - Chatwork
+      - ChatWork
     prh: （技術用語）
   - expected: DirectX
     patterns:


### PR DESCRIPTION
Chatwork Co., Ltd. changed company name and service name from "ChatWork" to "Chatwork" on 2018/11/28.

![image](https://user-images.githubusercontent.com/41186511/75774647-be26a200-5d93-11ea-9319-2a0f98fb67c1.png)

https://news-ja.chatwork.com/2018/11/new-mission.html
https://go.chatwork.com/ja/download/cw_logo.html