### PR TITLE
github.comはGitHubに修正しない

### DIFF
--- a/dict/prh_web_technology.yml
+++ b/dict/prh_web_technology.yml
@@ -82,7 +82,7 @@ rules:
   - expected: GitHub
     patterns:
       - Github
-      - github
+      - /github(?!([\.com]))/
       - Git Hub
       - git hub
     prh: （技術用語）


### PR DESCRIPTION
`https://github.com` と入力したいときに `GitHub` と修正した方がいいとサジェストされるのですが、ここは修正しなくてもいいのでルールを修正しました。

![github](https://user-images.githubusercontent.com/970868/80960643-39fca380-8e44-11ea-9689-12113ad15013.gif)
