### PR TITLE
「故に」のマッチに「事故に」がマッチしてしまうのを修正

### DIFF
--- a/dict/prh_open_close.yml
+++ b/dict/prh_open_close.yml
@@ -196,7 +196,7 @@ rules:
     expected: やすい
     prh: ひらがなで書くと読みやすくなります（ひらく漢字）
   - expected: ゆえに
-    pattern: 故に
+    pattern: /(?<!事)故に/
     prh: ひらがなで書くと読みやすくなります（ひらく漢字）
   - pattern: 分かる
     expected: わかる


### PR DESCRIPTION
関連: #5

「事故にあう」と記述した時に、「故に」でマッチしてしまい誤った指摘がされるのを修正します。