### PR TITLE
textlintrcのパスをモジュールとして利用できるようアップデート

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare module "textlint-rule-preset-icsmedia" {
+  export const configPath: string;
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+const path = require("path");
+const getConfigPath = () => {
+  return path.resolve(__dirname, ".textlintrc");
+};
+
+module.exports = {
+  /** textlintrcのファイルパスです */
+  configPath: getConfigPath(),
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "dependencies": {
     "textlint-rule-prh": "^5.2.0"
   },
+  "main": "index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "generate": "node _tools/長音表記統一.js",
     "format": "node _tools/YML整形ツール.js"


### PR DESCRIPTION
ICS MEDIAのtextlintルールをモジュールとして利用できるようパスを呼び出せる処理を作成しました。

```
import { configPath } from "textlint-rule-preset-icsmedia";
```
のような形でパスを利用できます。textlintの`loadTextlintrc({ configFilePath: configPath });`で読み込めばICS MEDIAのルールセットが使えるようになります。

ご確認お願いします。