### PR TITLE
助詞の連続の区切り文字オプション名の修正

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -11,7 +11,7 @@
         "min_interval" : 1,
         "strict": false,
         "allow": ["も", "や", "か"],
-        "separatorChars": ["、", "。", "?", "!", "？", "！", "「",  "」", "“", "”", "/", "／"]
+        "separatorCharacters": ["、", "。", "?", "!", "？", "！", "「",  "」", "“", "”", "/", "／"]
       },
       "no-mix-dearu-desumasu": true
     },


### PR DESCRIPTION
区切り文字のオプション名が誤っていたので、修正しました。
この修正で区切り文字の機能がきちんと動く見込みです。

ご確認お願いします。